### PR TITLE
Extend the pull monitor APIs to have more control over how it starts and carries on

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2015-06-21  Yothin Muangsommuk  <yothin@proteus-tech.com>
+ Extend the pull monitor APIs to have more control over how it starts and carries on
+
 2015-05-27  Kirit Sælensminde  <kirit@felspar.com>
  Disabled the end-of-request data capture in the request log because it caused problems for Postgres' serialized isolation level on some machines.
 

--- a/pubsubpull/api.py
+++ b/pubsubpull/api.py
@@ -44,3 +44,9 @@ def pull_up(model, callback, **kwargs):
     """
     schedule('pubsubpull.async.pullup_monitor',
         args=[model, callback], kwargs=kwargs)
+
+# def pull_down(model, callback, **kwargs):
+#     """Start a job pulling data from latest to beginning instance.
+#     """
+#     schedule('pubsubpull.async.pulldown_monitor',
+#         args=[model, callback], kwargs=kwargs)

--- a/pubsubpull/api.py
+++ b/pubsubpull/api.py
@@ -45,8 +45,8 @@ def pull_up(model, callback, **kwargs):
     schedule('pubsubpull.async.pullup_monitor',
         args=[model, callback], kwargs=kwargs)
 
-# def pull_down(model, callback, **kwargs):
-#     """Start a job pulling data from latest to beginning instance.
-#     """
-#     schedule('pubsubpull.async.pulldown_monitor',
-#         args=[model, callback], kwargs=kwargs)
+def pull_down(model, callback, **kwargs):
+    """Start a job pulling data from latest to beginning instance.
+    """
+    schedule('pubsubpull.async.pulldown_monitor',
+        args=[model, callback], kwargs=kwargs)

--- a/pubsubpull/api.py
+++ b/pubsubpull/api.py
@@ -50,3 +50,4 @@ def pull_down(model, callback, **kwargs):
     """
     schedule('pubsubpull.async.pulldown_monitor',
         args=[model, callback], kwargs=kwargs)
+

--- a/pubsubpull/api.py
+++ b/pubsubpull/api.py
@@ -37,3 +37,10 @@ def pull(model, callback, **kwargs):
     else:
         schedule('pubsubpull.async.pull_monitor',
             args=[model, callback], kwargs=kwargs)
+
+
+def pull_up(model, callback, **kwargs):
+    """Start a job monitoring new instance from latest instance.
+    """
+    schedule('pubsubpull.async.pullup_monitor',
+        args=[model, callback], kwargs=kwargs)

--- a/pubsubpull/api.py
+++ b/pubsubpull/api.py
@@ -49,14 +49,12 @@ def pull_up(model, callback, **kwargs):
     _, json = get(instance_url)
 
     schedule('pubsubpull.async.pull_monitor',
-        args=[model, callback],
-        kwargs=dict(floor=json['page'][0]['pk']))
+        args=[model, callback], kwargs=dict(floor=json['page'][0]['pk']))
 
 
 def pull_down(model, callback, **kwargs):
     """Start a job pulling data from latest to beginning instance.
     """
-    kwargs['delay'] = None
     schedule('pubsubpull.async.pull_monitor',
-        args=[model, callback], kwargs=kwargs)
+        args=[model, callback], kwargs=dict(delay=None))
 

--- a/pubsubpull/async.py
+++ b/pubsubpull/async.py
@@ -71,25 +71,25 @@ def pullup_monitor(model_url, callback, delay=dict(minutes=1),
     print("Looking for new instances above", highest)
 
 
-# def pulldown_monitor(model_url, callback, delay=dict(minutes=1),
-#         page_url=None, floor=0, pull_priority=5, job_priority=5):
-#
-#     if not page_url:
-#         model = get_model(model_url)
-#         instances_url = model._operations['instances']
-#     else:
-#         instances_url = page_url
-#     _, json = get(instances_url or page_url)
-#     latest, highest = None, floor
-#     for item in json['page']:
-#         highest = max(item['pk'], highest)
-#         latest = item['pk']
-#         if latest > floor:
-#             schedule(callback, args=[urljoin(instances_url, item['data'])], priority=job_priority)
-#     if json.has_key('next_page') and latest > floor:
-#         schedule('pubsubpull.async.pull_monitor', args=[model_url, callback],
-#              kwargs=dict(delay=delay, floor=floor,
-#                          page_url=urljoin(instances_url, json['next_page']),
-#                          pull_priority=pull_priority, job_priority=job_priority),
-#              priority=pull_priority)
-#     print("Got another page to process", json['next_page'], floor)
+def pulldown_monitor(model_url, callback, delay=dict(minutes=1),
+        page_url=None, floor=0, pull_priority=5, job_priority=5):
+
+    if not page_url:
+        model = get_model(model_url)
+        instances_url = model._operations['instances']
+    else:
+        instances_url = page_url
+    _, json = get(instances_url or page_url)
+    latest, highest = None, floor
+    for item in json['page']:
+        highest = max(item['pk'], highest)
+        latest = item['pk']
+        if latest > floor:
+            schedule(callback, args=[urljoin(instances_url, item['data'])], priority=job_priority)
+    if json.has_key('next_page') and latest > floor:
+        schedule('pubsubpull.async.pulldown_monitor', args=[model_url, callback],
+             kwargs=dict(delay=delay, floor=floor,
+                         page_url=urljoin(instances_url, json['next_page']),
+                         pull_priority=pull_priority, job_priority=job_priority),
+             priority=pull_priority)
+        print("Got another page to process", json['next_page'], floor)

--- a/pubsubpull/async.py
+++ b/pubsubpull/async.py
@@ -56,19 +56,19 @@ def pullup_monitor(model_url, callback, delay=dict(minutes=1),
     model = get_model(model_url)
     instance_url = model._operations['instances']
     _, json = get(instance_url)
+    latest, highest = None, floor
     for item in json['page']:
-        highest = max(item['pk'], floor)
+        highest = max(item['pk'], highest)
         latest = item['pk']
         if latest > floor:
             schedule(callback, args=[urljoin(instance_url, item['data'])], priority=job_priority)
 
-    if latest > highest or floor == 0:
-        run_after = timezone.now() + timedelta(**delay)
-        schedule('pubsubpull.async.pullup_monitor', run_after=run_after,
-            args=[model_url, callback], kwargs=dict(delay=delay, floor=highest,
-                pull_priority=pull_priority, job_priority=job_priority),
-            priority=pull_priority)
-        print("Looking for new instances above", highest)
+    run_after = timezone.now() + timedelta(**delay)
+    schedule('pubsubpull.async.pullup_monitor', run_after=run_after,
+        args=[model_url, callback], kwargs=dict(delay=delay, floor=highest,
+            pull_priority=pull_priority, job_priority=job_priority),
+        priority=pull_priority)
+    print("Looking for new instances above", highest)
 
 
 # def pulldown_monitor(model_url, callback, delay=dict(minutes=1),

--- a/pubsubpull/async.py
+++ b/pubsubpull/async.py
@@ -52,18 +52,44 @@ def pull_monitor(model_url, callback, delay=dict(minutes=1),
 
 def pullup_monitor(model_url, callback, delay=dict(minutes=1),
         page_url=None, floor=0, pull_priority=5, job_priority=5):
-    """Used to look for instances that need to be pulled.
-        This only works with models who use an auto-incremented primary key.
-    """
+
     model = get_model(model_url)
     instance_url = model._operations['instances']
     _, json = get(instance_url)
     for item in json['page']:
-        floor = max(item['pk'], floor)
+        highest = max(item['pk'], floor)
+        latest = item['pk']
+        if latest > floor:
+            schedule(callback, args=[urljoin(instance_url, item['data'])], priority=job_priority)
 
-    run_after = timezone.now() + timedelta(**delay)
-    schedule('pubsubpull.async.pullup_monitor', run_after=run_after,
-        args=[model_url, callback], kwargs=dict(delay=delay, floor=floor,
-            pull_priority=pull_priority, job_priority=job_priority),
-        priority=pull_priority)
-    print("Looking for new instances above", floor)
+    if latest > highest or floor == 0:
+        run_after = timezone.now() + timedelta(**delay)
+        schedule('pubsubpull.async.pullup_monitor', run_after=run_after,
+            args=[model_url, callback], kwargs=dict(delay=delay, floor=highest,
+                pull_priority=pull_priority, job_priority=job_priority),
+            priority=pull_priority)
+        print("Looking for new instances above", highest)
+
+
+# def pulldown_monitor(model_url, callback, delay=dict(minutes=1),
+#         page_url=None, floor=0, pull_priority=5, job_priority=5):
+#
+#     if not page_url:
+#         model = get_model(model_url)
+#         instances_url = model._operations['instances']
+#     else:
+#         instances_url = page_url
+#     _, json = get(instances_url or page_url)
+#     latest, highest = None, floor
+#     for item in json['page']:
+#         highest = max(item['pk'], highest)
+#         latest = item['pk']
+#         if latest > floor:
+#             schedule(callback, args=[urljoin(instances_url, item['data'])], priority=job_priority)
+#     if json.has_key('next_page') and latest > floor:
+#         schedule('pubsubpull.async.pull_monitor', args=[model_url, callback],
+#              kwargs=dict(delay=delay, floor=floor,
+#                          page_url=urljoin(instances_url, json['next_page']),
+#                          pull_priority=pull_priority, job_priority=job_priority),
+#              priority=pull_priority)
+#     print("Got another page to process", json['next_page'], floor)

--- a/pubsubpull/async.py
+++ b/pubsubpull/async.py
@@ -41,7 +41,7 @@ def pull_monitor(model_url, callback, delay=dict(minutes=1),
                 pull_priority=pull_priority, job_priority=job_priority),
             priority=pull_priority)
         print("Got another page to process", json['next_page'], floor)
-    if not page_url:
+    if not page_url and delay:
         run_after = timezone.now() + timedelta(**delay)
         schedule('pubsubpull.async.pull_monitor', run_after=run_after,
             args=[model_url, callback], kwargs=dict(delay=delay, floor=highest,
@@ -50,46 +50,3 @@ def pull_monitor(model_url, callback, delay=dict(minutes=1),
         print("Looking for new instances above", highest)
 
 
-def pullup_monitor(model_url, callback, delay=dict(minutes=1),
-        page_url=None, floor=0, pull_priority=5, job_priority=5):
-
-    model = get_model(model_url)
-    instance_url = model._operations['instances']
-    _, json = get(instance_url)
-    latest, highest = None, floor
-    for item in json['page']:
-        highest = max(item['pk'], highest)
-        latest = item['pk']
-        if latest > floor:
-            schedule(callback, args=[urljoin(instance_url, item['data'])], priority=job_priority)
-
-    run_after = timezone.now() + timedelta(**delay)
-    schedule('pubsubpull.async.pullup_monitor', run_after=run_after,
-        args=[model_url, callback], kwargs=dict(delay=delay, floor=highest,
-            pull_priority=pull_priority, job_priority=job_priority),
-        priority=pull_priority)
-    print("Looking for new instances above", highest)
-
-
-def pulldown_monitor(model_url, callback, delay=dict(minutes=1),
-        page_url=None, floor=0, pull_priority=5, job_priority=5):
-
-    if not page_url:
-        model = get_model(model_url)
-        instances_url = model._operations['instances']
-    else:
-        instances_url = page_url
-    _, json = get(instances_url or page_url)
-    latest, highest = None, floor
-    for item in json['page']:
-        highest = max(item['pk'], highest)
-        latest = item['pk']
-        if latest > floor:
-            schedule(callback, args=[urljoin(instances_url, item['data'])], priority=job_priority)
-    if json.has_key('next_page') and latest > floor:
-        schedule('pubsubpull.async.pulldown_monitor', args=[model_url, callback],
-             kwargs=dict(delay=delay, floor=floor,
-                         page_url=urljoin(instances_url, json['next_page']),
-                         pull_priority=pull_priority, job_priority=job_priority),
-             priority=pull_priority)
-        print("Got another page to process", json['next_page'], floor)

--- a/pubsubpull/async.py
+++ b/pubsubpull/async.py
@@ -48,3 +48,22 @@ def pull_monitor(model_url, callback, delay=dict(minutes=1),
                 pull_priority=pull_priority, job_priority=job_priority),
             priority=pull_priority)
         print("Looking for new instances above", highest)
+
+
+def pullup_monitor(model_url, callback, delay=dict(minutes=1),
+        page_url=None, floor=0, pull_priority=5, job_priority=5):
+    """Used to look for instances that need to be pulled.
+        This only works with models who use an auto-incremented primary key.
+    """
+    model = get_model(model_url)
+    instance_url = model._operations['instances']
+    _, json = get(instance_url)
+    for item in json['page']:
+        floor = max(item['pk'], floor)
+
+    run_after = timezone.now() + timedelta(**delay)
+    schedule('pubsubpull.async.pullup_monitor', run_after=run_after,
+        args=[model_url, callback], kwargs=dict(delay=delay, floor=floor,
+            pull_priority=pull_priority, job_priority=job_priority),
+        priority=pull_priority)
+    print("Looking for new instances above", floor)

--- a/pubsubpull/tests/test_pull.py
+++ b/pubsubpull/tests/test_pull.py
@@ -96,27 +96,26 @@ class TestPullStarts(TestCase):
     def test_pull_up_monitor(self):
         pizzas = []
         pizzas.append(Pizza.objects.create(name="Pizza %s" % 1))
+        pizzas.append(Pizza.objects.create(name="Pizza %s" % 2))
         pull_up('slumber://pizza/slumber_examples/Pizza/', 'pubsubpull.tests.test_pull.job')
-        self.assertEquals(Job.objects.count(), 1) #have initial pull_up job
-        import ipdb; ipdb.set_trace()
+        self.assertEquals(Job.objects.count(), 1)
         management.call_command('flush_queue')
 
         #have 1 job monitor to run and 1 call back job
-        self.assertEquals(Job.objects.filter(name='pubsubpull.tests.test_pull.job').count(), 1)
+        self.assertEquals(Job.objects.filter(name='pubsubpull.tests.test_pull.job').count(), 2)
         self.assertEquals(Job.objects.filter(name='pubsubpull.async.pullup_monitor', executed=None).count(), 1)
 
         print("*** -- dropping scheduled time on jobs to force execution")
         Job.objects.exclude(scheduled=None).update(scheduled=None)
 
-        #add to object so it will monitor the latest one and create callback job for both instance
-        pizzas.append(Pizza.objects.create(name="Pizza %s" % 2))
+        #add objects so it will monitor the latest one and create callback job for both instance
         pizzas.append(Pizza.objects.create(name="Pizza %s" % 3))
+        pizzas.append(Pizza.objects.create(name="Pizza %s" % 4))
 
-        ipdb.set_trace()
         management.call_command('flush_queue')
 
-        #should have 1 monitor job for floor=62
+        #should have 1 monitor job for floor=63
         self.assertEquals(Job.objects.filter(name='pubsubpull.async.pullup_monitor', executed=None).count(), 1)
-
-        # self.assertEquals(Job.objects.filter(executed=None).count(), 1)
+        self.check_pizzas(pizzas)
         return pizzas
+

--- a/pubsubpull/tests/test_pull.py
+++ b/pubsubpull/tests/test_pull.py
@@ -123,4 +123,5 @@ class TestPullStarts(TestCase):
         management.call_command('flush_queue')
         self.assertEquals(Job.objects.filter(name='pubsubpull.async.pulldown_monitor').count(), 3)
         self.assertEquals(Job.objects.filter(name='pubsubpull.tests.test_pull.job').count(), 11)
+        self.assertEquals(Job.objects.filter(executed=None).count(), 0)
         self.check_pizzas(pizzas)

--- a/pubsubpull/tests/test_pull.py
+++ b/pubsubpull/tests/test_pull.py
@@ -124,4 +124,3 @@ class TestPullStarts(TestCase):
         self.assertEquals(Job.objects.filter(name='pubsubpull.async.pulldown_monitor').count(), 3)
         self.assertEquals(Job.objects.filter(name='pubsubpull.tests.test_pull.job').count(), 11)
         self.check_pizzas(pizzas)
-

--- a/runtests
+++ b/runtests
@@ -16,12 +16,3 @@ cd test-projects/django_1_4
 echo Django 1.4
 check_worked python -tt manage.py test pubsubpull
 
-workon pubsubpull_1.7
-cd ../django_1_7
-echo Django 1.7
-check_worked python manage.py test pubsubpull
-
-workon pubsubpull_1.0
-cd ../django_1_0
-echo Django 1.0
-check_worked python manage.py test d1

--- a/runtests
+++ b/runtests
@@ -16,3 +16,12 @@ cd test-projects/django_1_4
 echo Django 1.4
 check_worked python -tt manage.py test pubsubpull
 
+workon pubsubpull_1.7
+cd ../django_1_7
+echo Django 1.7
+check_worked python manage.py test pubsubpull
+
+workon pubsubpull_1.0
+cd ../django_1_0
+echo Django 1.0
+check_worked python manage.py test d1

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ if sys.version_info >= (3,):
 
 setup(
     name = "django-pubsubpull",
-    version = "0.1.0.3",
+    version = "0.1.0.4",
     author = "Kirit Saelensminde",
     author_email = "kirit@felspar.com",
     url='https://github.com/KayEss/django-pubsubpull',


### PR DESCRIPTION
- Added pull_up API that will only look for new instances
- Added pull_down API that will not look for new instances
